### PR TITLE
[RMTCB-44142] Update latest telemetry version 1.0.2 to fix logging issue in GCP log explorer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
 
-optiva.addJobParam(stringParam(name: 'VERSION', defaultValue: '2.1.4',
+optiva.addJobParam(stringParam(name: 'VERSION', defaultValue: '2.1.5',
                             description: 'Semantic version for the produced artifacts'))
                             
 optiva.addJobParam(stringParam(name: 'GOLANG_VERSION', defaultValue: '1.19.3'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
 
-optiva.addJobParam(stringParam(name: 'VERSION', defaultValue: '2.1.5',
+optiva.addJobParam(stringParam(name: 'VERSION', defaultValue: '2.1.6',
                             description: 'Semantic version for the produced artifacts'))
                             
 optiva.addJobParam(stringParam(name: 'GOLANG_VERSION', defaultValue: '1.19.3'))

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 BIN_NAME :=krakend
 OS := $(shell uname | tr '[:upper:]' '[:lower:]')
-VERSION := 2.1.5
+VERSION := 2.1.6
 GIT_COMMIT := $(shell git rev-parse --short=7 HEAD)
 PKGNAME := krakend
 LICENSE := Apache 2.0

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/krakendio/krakend-viper/v2 v2.0.1
 	github.com/krakendio/krakend-xml/v2 v2.0.1
 	github.com/luraproject/lura/v2 v2.2.2
-	github.com/optivainc/optiva-product-shared-krakend-telemetry v1.0.0
+	github.com/optivainc/optiva-product-shared-krakend-telemetry v1.0.1-0.20250311143756-1f16951ea63f
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.36.4
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/krakendio/krakend-viper/v2 v2.0.1
 	github.com/krakendio/krakend-xml/v2 v2.0.1
 	github.com/luraproject/lura/v2 v2.2.2
-	github.com/optivainc/optiva-product-shared-krakend-telemetry v1.0.1-0.20250311143756-1f16951ea63f
+	github.com/optivainc/optiva-product-shared-krakend-telemetry v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.36.4
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )


### PR DESCRIPTION
PR version build is tested and now SEVERITY is updating correctly in GCP log explorer.
![image](https://github.com/user-attachments/assets/fdbf4898-1906-4181-ba9a-f2f0cb9c7918)
![image](https://github.com/user-attachments/assets/1c4d25bd-fdda-4c19-9d9f-2274b31203c4)
