### PR TITLE
[bugfix/0.50493.0] checkin go.sum after executing go mod tidy

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -595,10 +595,8 @@ github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWEr
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.5 h1:UwtQQx2pyPIgWYHRg+epgdx1/HnBQTgN3/oIYEJTQzU=
 github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa4YDFlwRYAMyE=
-github.com/optivainc/optiva-product-shared-krakend-telemetry v1.0.2-0.20250408234053-7fb5ada43cbe h1:HH2pAnl3AOV7n/plVl5w1PA3ToEzPoPN+pPDzFYUHgQ=
-github.com/optivainc/optiva-product-shared-krakend-telemetry v1.0.2-0.20250408234053-7fb5ada43cbe/go.mod h1:J7rvt+pBMjSv7sAhJnbfn36PyGwWgxEHaX0WZc5vj+Y=
-github.com/optivainc/optiva-product-shared-krakend-telemetry v1.2.0 h1:sEHhb3DADIbgEoERUveuVmGIUzCZySbwpHSO4ajkXGQ=
-github.com/optivainc/optiva-product-shared-krakend-telemetry v1.2.0/go.mod h1:J7rvt+pBMjSv7sAhJnbfn36PyGwWgxEHaX0WZc5vj+Y=
+github.com/optivainc/optiva-product-shared-krakend-telemetry v1.3.0 h1:UOicnvBkqHBr+AciQlxoYpO+52xzzdRmY+/N0RGMru8=
+github.com/optivainc/optiva-product-shared-krakend-telemetry v1.3.0/go.mod h1:T06FfPRZ4myCgRX+VC6FDsl7I5nyvo/AxE7icwTGxKc=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=


### PR DESCRIPTION
**JIRA**: 
- https://optiva.atlassian.net/browse/RMTCB-50493 (mainline merge ticket)
- https://optiva.atlassian.net/browse/RMTCB-45289 (original ticket)

**description**:
checkin go.sum after executing go mod tidy

**related PR**: 
- https://github.com/OptivaInc/Optiva-Product-Shared-KrakenD-Plugins/pull/68
- https://github.com/OptivaInc/Optiva-Product-Shared-KrakenD-Telemetry/pull/22
- https://github.com/OptivaInc/OBP-Product-RTS-Apigw/pull/677